### PR TITLE
Move defer f.Close to right position.

### DIFF
--- a/csaf/advisory.go
+++ b/csaf/advisory.go
@@ -781,14 +781,11 @@ func LoadAdvisory(fname string) (*Advisory, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	defer f.Close()
 	var advisory Advisory
-	dec := json.NewDecoder(f)
-	if err := dec.Decode(&advisory); err != nil {
+	if err := json.NewDecoder(f).Decode(&advisory); err != nil {
 		return nil, err
 	}
-	defer f.Close()
-
 	return &advisory, nil
 }
 


### PR DESCRIPTION
`defer f.Close` has to be called right after the error check if the file is open.