### PR TITLE
Add generator for CVSS enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Download the binaries from the most recent release assets on Github.
 
 Binaries will be placed in directories named like `bin-linux-amd64/` and `bin-windows-amd64/`.
 
+- Maintainers only: No need to do this if you have cloned this repository for unmodified usage only.
+```
+go generate ./...
+```
+will update the machine generated code.
+
 
 ### Setup (Trusted Provider)
 

--- a/csaf/advisory.go
+++ b/csaf/advisory.go
@@ -653,59 +653,59 @@ var CVSSv3VersionPattern = alternativesUnmarshal(
 
 // CVSSv2 holding a CVSS v2.0 value
 type CVSSv2 struct {
-	Version                    string  `json:"version"`      // required
-	VectorString               string  `json:"vectorString"` // required
-	AccessVector               *string `json:"accessVector"`
-	AccessComplexity           *string `json:"accessComplexity"`
-	Authentication             *string `json:"authentication"`
-	ConfidentialityImpact      *string `json:"confidentialityImpact"`
-	IntegrityImpact            *string `json:"integrityImpact"`
-	AvailabilityImpact         *string `json:"availabilityImpact"`
-	BaseScore                  float64 `json:"baseScore"` // required
-	Exploitability             *string `json:"exploitability"`
-	RemediationLevel           *string `json:"remediationLevel"`
-	ReportConfidence           *string `json:"reportConfidence"`
-	TemporalScore              *string `json:"temporalScore"`
-	CollateralDamagePotential  *string `json:"collateralDamagePotential"`
-	TargetDistribution         *string `json:"targetDistribution"`
-	ConfidentialityRequirement *string `json:"confidentialityRequirement"`
-	IntegrityRequirement       *string `json:"integrityRequirement"`
-	AvailabilityRequirement    *string `json:"availabilityRequirement"`
-	EnvironmentalScore         *string `json:"environmentalScore"`
+	Version                    string                           `json:"version"`      // required
+	VectorString               string                           `json:"vectorString"` // required
+	AccessVector               *CVSS20AccessVector              `json:"accessVector"`
+	AccessComplexity           *CVSS20AccessComplexity          `json:"accessComplexity"`
+	Authentication             *CVSS20Authentication            `json:"authentication"`
+	ConfidentialityImpact      *string                          `json:"confidentialityImpact"`
+	IntegrityImpact            *string                          `json:"integrityImpact"`
+	AvailabilityImpact         *string                          `json:"availabilityImpact"`
+	BaseScore                  float64                          `json:"baseScore"` // required
+	Exploitability             *CVSS20Exploitability            `json:"exploitability"`
+	RemediationLevel           *CVSS20RemediationLevel          `json:"remediationLevel"`
+	ReportConfidence           *string                          `json:"reportConfidence"`
+	TemporalScore              *string                          `json:"temporalScore"`
+	CollateralDamagePotential  *CVSS20CollateralDamagePotential `json:"collateralDamagePotential"`
+	TargetDistribution         *CVSS20TargetDistribution        `json:"targetDistribution"`
+	ConfidentialityRequirement *string                          `json:"confidentialityRequirement"`
+	IntegrityRequirement       *string                          `json:"integrityRequirement"`
+	AvailabilityRequirement    *string                          `json:"availabilityRequirement"`
+	EnvironmentalScore         *string                          `json:"environmentalScore"`
 }
 
 // CVSSv3 holding a CVSS v3.x value
 type CVSSv3 struct {
-	Version                       string  `json:"version"`      // required
-	VectorString                  string  `json:"vectorString"` // required
-	AttackVector                  *string `json:"attackVector"`
-	AttackComplexity              *string `json:"attackComplexity"`
-	PrivilegesRequired            *string `json:"privilegesRequired"`
-	UserInteraction               *string `json:"userInteraction"`
-	Scope                         *string `json:"scope"`
-	ConfidentialityImpact         *string `json:"confidentialityImpact"`
-	IntegrityImpact               string  `json:"integrityImpact"`
-	AvailabilityImpact            *string `json:"availabilityImpact"`
-	BaseScore                     float64 `json:"baseScore"`    // required
-	BaseSeverity                  string  `json:"baseSeverity"` // required
-	ExploitCodeMaturity           *string `json:"exploitCodeMaturity"`
-	RemediationLevel              *string `json:"remediationLevel"`
-	ReportConfidence              *string `json:"reportConfidence"`
-	TemporalScore                 *string `json:"temporalScore"`
-	TemporalSeverity              *string `json:"temporalSeverity"`
-	ConfidentialityRequirement    *string `json:"confidentialityRequirement"`
-	IntegrityRequirement          *string `json:"integrityRequirement"`
-	AvailabilityRequirement       *string `json:"availabilityRequirement"`
-	ModifiedAttackVector          *string `json:"modifiedAttackVector"`
-	ModifiedAttackComplexity      *string `json:"modifiedAttackComplexity"`
-	ModifiedPrivilegesRequired    *string `json:"modifiedPrivilegesRequired"`
-	ModifiedUserInteraction       *string `json:"modifiedUserInteraction"`
-	ModifiedScope                 *string `json:"modifiedScope"`
-	ModifiedConfidentialityImpact *string `json:"modifiedConfidentialityImpact"`
-	ModifiedIntegrityImpact       *string `json:"modifiedIntegrityImpact"`
-	ModifiedAvailabilityImpact    *string `json:"modifiedAvailabilityImpact"`
-	EenvironmentalScore           *string `json:"environmentalScore"`
-	EnvironmentalSeverity         *string `json:"environmentalSeverity"`
+	Version                       string                          `json:"version"`      // required
+	VectorString                  string                          `json:"vectorString"` // required
+	AttackVector                  *string                         `json:"attackVector"`
+	AttackComplexity              *CVSS30AttackComplexity         `json:"attackComplexity"`
+	PrivilegesRequired            *CVSS30PrivilegesRequired       `json:"privilegesRequired"`
+	UserInteraction               *CVSS30UserInteraction          `json:"userInteraction"`
+	Scope                         *CVSS30Scope                    `json:"scope"`
+	ConfidentialityImpact         *string                         `json:"confidentialityImpact"`
+	IntegrityImpact               string                          `json:"integrityImpact"`
+	AvailabilityImpact            *string                         `json:"availabilityImpact"`
+	BaseScore                     float64                         `json:"baseScore"`    // required
+	BaseSeverity                  string                          `json:"baseSeverity"` // required
+	ExploitCodeMaturity           *CVSS30ExploitCodeMaturity      `json:"exploitCodeMaturity"`
+	RemediationLevel              *CVSS30RemediationLevel         `json:"remediationLevel"`
+	ReportConfidence              *string                         `json:"reportConfidence"`
+	TemporalScore                 *string                         `json:"temporalScore"`
+	TemporalSeverity              *string                         `json:"temporalSeverity"`
+	ConfidentialityRequirement    *string                         `json:"confidentialityRequirement"`
+	IntegrityRequirement          *string                         `json:"integrityRequirement"`
+	AvailabilityRequirement       *string                         `json:"availabilityRequirement"`
+	ModifiedAttackVector          *CVSS30ModifiedAttackVector     `json:"modifiedAttackVector"`
+	ModifiedAttackComplexity      *CVSS30ModifiedAttackComplexity `json:"modifiedAttackComplexity"`
+	ModifiedPrivilegesRequired    *string                         `json:"modifiedPrivilegesRequired"`
+	ModifiedUserInteraction       *string                         `json:"modifiedUserInteraction"`
+	ModifiedScope                 *string                         `json:"modifiedScope"`
+	ModifiedConfidentialityImpact *string                         `json:"modifiedConfidentialityImpact"`
+	ModifiedIntegrityImpact       *string                         `json:"modifiedIntegrityImpact"`
+	ModifiedAvailabilityImpact    *string                         `json:"modifiedAvailabilityImpact"`
+	EenvironmentalScore           *string                         `json:"environmentalScore"`
+	EnvironmentalSeverity         *string                         `json:"environmentalSeverity"`
 }
 
 // Score specifies information about (at least one) score of the vulnerability and for which

--- a/csaf/cvss20enums.go
+++ b/csaf/cvss20enums.go
@@ -1,0 +1,314 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+//
+// THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
+
+package csaf
+
+// CVSS20AccessComplexity represents the accessComplexityType in CVSS20.
+type CVSS20AccessComplexity string
+
+const (
+	// CVSS20AccessComplexityHigh is a constant for "HIGH".
+	CVSS20AccessComplexityHigh CVSS20AccessComplexity = "HIGH"
+	// CVSS20AccessComplexityMedium is a constant for "MEDIUM".
+	CVSS20AccessComplexityMedium CVSS20AccessComplexity = "MEDIUM"
+	// CVSS20AccessComplexityLow is a constant for "LOW".
+	CVSS20AccessComplexityLow CVSS20AccessComplexity = "LOW"
+)
+
+var cvss20AccessComplexityPattern = alternativesUnmarshal(
+	string(CVSS20AccessComplexityHigh),
+	string(CVSS20AccessComplexityMedium),
+	string(CVSS20AccessComplexityLow),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20AccessComplexity) UnmarshalText(data []byte) error {
+	s, err := cvss20AccessComplexityPattern(data)
+	if err == nil {
+		*e = CVSS20AccessComplexity(s)
+	}
+	return err
+}
+
+// CVSS20AccessVector represents the accessVectorType in CVSS20.
+type CVSS20AccessVector string
+
+const (
+	// CVSS20AccessVectorNetwork is a constant for "NETWORK".
+	CVSS20AccessVectorNetwork CVSS20AccessVector = "NETWORK"
+	// CVSS20AccessVectorAdjacentNetwork is a constant for "ADJACENT_NETWORK".
+	CVSS20AccessVectorAdjacentNetwork CVSS20AccessVector = "ADJACENT_NETWORK"
+	// CVSS20AccessVectorLocal is a constant for "LOCAL".
+	CVSS20AccessVectorLocal CVSS20AccessVector = "LOCAL"
+)
+
+var cvss20AccessVectorPattern = alternativesUnmarshal(
+	string(CVSS20AccessVectorNetwork),
+	string(CVSS20AccessVectorAdjacentNetwork),
+	string(CVSS20AccessVectorLocal),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20AccessVector) UnmarshalText(data []byte) error {
+	s, err := cvss20AccessVectorPattern(data)
+	if err == nil {
+		*e = CVSS20AccessVector(s)
+	}
+	return err
+}
+
+// CVSS20Authentication represents the authenticationType in CVSS20.
+type CVSS20Authentication string
+
+const (
+	// CVSS20AuthenticationMultiple is a constant for "MULTIPLE".
+	CVSS20AuthenticationMultiple CVSS20Authentication = "MULTIPLE"
+	// CVSS20AuthenticationSingle is a constant for "SINGLE".
+	CVSS20AuthenticationSingle CVSS20Authentication = "SINGLE"
+	// CVSS20AuthenticationNone is a constant for "NONE".
+	CVSS20AuthenticationNone CVSS20Authentication = "NONE"
+)
+
+var cvss20AuthenticationPattern = alternativesUnmarshal(
+	string(CVSS20AuthenticationMultiple),
+	string(CVSS20AuthenticationSingle),
+	string(CVSS20AuthenticationNone),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20Authentication) UnmarshalText(data []byte) error {
+	s, err := cvss20AuthenticationPattern(data)
+	if err == nil {
+		*e = CVSS20Authentication(s)
+	}
+	return err
+}
+
+// CVSS20CiaRequirement represents the ciaRequirementType in CVSS20.
+type CVSS20CiaRequirement string
+
+const (
+	// CVSS20CiaRequirementLow is a constant for "LOW".
+	CVSS20CiaRequirementLow CVSS20CiaRequirement = "LOW"
+	// CVSS20CiaRequirementMedium is a constant for "MEDIUM".
+	CVSS20CiaRequirementMedium CVSS20CiaRequirement = "MEDIUM"
+	// CVSS20CiaRequirementHigh is a constant for "HIGH".
+	CVSS20CiaRequirementHigh CVSS20CiaRequirement = "HIGH"
+	// CVSS20CiaRequirementNotDefined is a constant for "NOT_DEFINED".
+	CVSS20CiaRequirementNotDefined CVSS20CiaRequirement = "NOT_DEFINED"
+)
+
+var cvss20CiaRequirementPattern = alternativesUnmarshal(
+	string(CVSS20CiaRequirementLow),
+	string(CVSS20CiaRequirementMedium),
+	string(CVSS20CiaRequirementHigh),
+	string(CVSS20CiaRequirementNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20CiaRequirement) UnmarshalText(data []byte) error {
+	s, err := cvss20CiaRequirementPattern(data)
+	if err == nil {
+		*e = CVSS20CiaRequirement(s)
+	}
+	return err
+}
+
+// CVSS20Cia represents the ciaType in CVSS20.
+type CVSS20Cia string
+
+const (
+	// CVSS20CiaNone is a constant for "NONE".
+	CVSS20CiaNone CVSS20Cia = "NONE"
+	// CVSS20CiaPartial is a constant for "PARTIAL".
+	CVSS20CiaPartial CVSS20Cia = "PARTIAL"
+	// CVSS20CiaComplete is a constant for "COMPLETE".
+	CVSS20CiaComplete CVSS20Cia = "COMPLETE"
+)
+
+var cvss20CiaPattern = alternativesUnmarshal(
+	string(CVSS20CiaNone),
+	string(CVSS20CiaPartial),
+	string(CVSS20CiaComplete),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20Cia) UnmarshalText(data []byte) error {
+	s, err := cvss20CiaPattern(data)
+	if err == nil {
+		*e = CVSS20Cia(s)
+	}
+	return err
+}
+
+// CVSS20CollateralDamagePotential represents the collateralDamagePotentialType in CVSS20.
+type CVSS20CollateralDamagePotential string
+
+const (
+	// CVSS20CollateralDamagePotentialNone is a constant for "NONE".
+	CVSS20CollateralDamagePotentialNone CVSS20CollateralDamagePotential = "NONE"
+	// CVSS20CollateralDamagePotentialLow is a constant for "LOW".
+	CVSS20CollateralDamagePotentialLow CVSS20CollateralDamagePotential = "LOW"
+	// CVSS20CollateralDamagePotentialLowMedium is a constant for "LOW_MEDIUM".
+	CVSS20CollateralDamagePotentialLowMedium CVSS20CollateralDamagePotential = "LOW_MEDIUM"
+	// CVSS20CollateralDamagePotentialMediumHigh is a constant for "MEDIUM_HIGH".
+	CVSS20CollateralDamagePotentialMediumHigh CVSS20CollateralDamagePotential = "MEDIUM_HIGH"
+	// CVSS20CollateralDamagePotentialHigh is a constant for "HIGH".
+	CVSS20CollateralDamagePotentialHigh CVSS20CollateralDamagePotential = "HIGH"
+	// CVSS20CollateralDamagePotentialNotDefined is a constant for "NOT_DEFINED".
+	CVSS20CollateralDamagePotentialNotDefined CVSS20CollateralDamagePotential = "NOT_DEFINED"
+)
+
+var cvss20CollateralDamagePotentialPattern = alternativesUnmarshal(
+	string(CVSS20CollateralDamagePotentialNone),
+	string(CVSS20CollateralDamagePotentialLow),
+	string(CVSS20CollateralDamagePotentialLowMedium),
+	string(CVSS20CollateralDamagePotentialMediumHigh),
+	string(CVSS20CollateralDamagePotentialHigh),
+	string(CVSS20CollateralDamagePotentialNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20CollateralDamagePotential) UnmarshalText(data []byte) error {
+	s, err := cvss20CollateralDamagePotentialPattern(data)
+	if err == nil {
+		*e = CVSS20CollateralDamagePotential(s)
+	}
+	return err
+}
+
+// CVSS20Exploitability represents the exploitabilityType in CVSS20.
+type CVSS20Exploitability string
+
+const (
+	// CVSS20ExploitabilityUnproven is a constant for "UNPROVEN".
+	CVSS20ExploitabilityUnproven CVSS20Exploitability = "UNPROVEN"
+	// CVSS20ExploitabilityProofOfConcept is a constant for "PROOF_OF_CONCEPT".
+	CVSS20ExploitabilityProofOfConcept CVSS20Exploitability = "PROOF_OF_CONCEPT"
+	// CVSS20ExploitabilityFunctional is a constant for "FUNCTIONAL".
+	CVSS20ExploitabilityFunctional CVSS20Exploitability = "FUNCTIONAL"
+	// CVSS20ExploitabilityHigh is a constant for "HIGH".
+	CVSS20ExploitabilityHigh CVSS20Exploitability = "HIGH"
+	// CVSS20ExploitabilityNotDefined is a constant for "NOT_DEFINED".
+	CVSS20ExploitabilityNotDefined CVSS20Exploitability = "NOT_DEFINED"
+)
+
+var cvss20ExploitabilityPattern = alternativesUnmarshal(
+	string(CVSS20ExploitabilityUnproven),
+	string(CVSS20ExploitabilityProofOfConcept),
+	string(CVSS20ExploitabilityFunctional),
+	string(CVSS20ExploitabilityHigh),
+	string(CVSS20ExploitabilityNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20Exploitability) UnmarshalText(data []byte) error {
+	s, err := cvss20ExploitabilityPattern(data)
+	if err == nil {
+		*e = CVSS20Exploitability(s)
+	}
+	return err
+}
+
+// CVSS20RemediationLevel represents the remediationLevelType in CVSS20.
+type CVSS20RemediationLevel string
+
+const (
+	// CVSS20RemediationLevelOfficialFix is a constant for "OFFICIAL_FIX".
+	CVSS20RemediationLevelOfficialFix CVSS20RemediationLevel = "OFFICIAL_FIX"
+	// CVSS20RemediationLevelTemporaryFix is a constant for "TEMPORARY_FIX".
+	CVSS20RemediationLevelTemporaryFix CVSS20RemediationLevel = "TEMPORARY_FIX"
+	// CVSS20RemediationLevelWorkaround is a constant for "WORKAROUND".
+	CVSS20RemediationLevelWorkaround CVSS20RemediationLevel = "WORKAROUND"
+	// CVSS20RemediationLevelUnavailable is a constant for "UNAVAILABLE".
+	CVSS20RemediationLevelUnavailable CVSS20RemediationLevel = "UNAVAILABLE"
+	// CVSS20RemediationLevelNotDefined is a constant for "NOT_DEFINED".
+	CVSS20RemediationLevelNotDefined CVSS20RemediationLevel = "NOT_DEFINED"
+)
+
+var cvss20RemediationLevelPattern = alternativesUnmarshal(
+	string(CVSS20RemediationLevelOfficialFix),
+	string(CVSS20RemediationLevelTemporaryFix),
+	string(CVSS20RemediationLevelWorkaround),
+	string(CVSS20RemediationLevelUnavailable),
+	string(CVSS20RemediationLevelNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20RemediationLevel) UnmarshalText(data []byte) error {
+	s, err := cvss20RemediationLevelPattern(data)
+	if err == nil {
+		*e = CVSS20RemediationLevel(s)
+	}
+	return err
+}
+
+// CVSS20ReportConfidence represents the reportConfidenceType in CVSS20.
+type CVSS20ReportConfidence string
+
+const (
+	// CVSS20ReportConfidenceUnconfirmed is a constant for "UNCONFIRMED".
+	CVSS20ReportConfidenceUnconfirmed CVSS20ReportConfidence = "UNCONFIRMED"
+	// CVSS20ReportConfidenceUncorroborated is a constant for "UNCORROBORATED".
+	CVSS20ReportConfidenceUncorroborated CVSS20ReportConfidence = "UNCORROBORATED"
+	// CVSS20ReportConfidenceConfirmed is a constant for "CONFIRMED".
+	CVSS20ReportConfidenceConfirmed CVSS20ReportConfidence = "CONFIRMED"
+	// CVSS20ReportConfidenceNotDefined is a constant for "NOT_DEFINED".
+	CVSS20ReportConfidenceNotDefined CVSS20ReportConfidence = "NOT_DEFINED"
+)
+
+var cvss20ReportConfidencePattern = alternativesUnmarshal(
+	string(CVSS20ReportConfidenceUnconfirmed),
+	string(CVSS20ReportConfidenceUncorroborated),
+	string(CVSS20ReportConfidenceConfirmed),
+	string(CVSS20ReportConfidenceNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20ReportConfidence) UnmarshalText(data []byte) error {
+	s, err := cvss20ReportConfidencePattern(data)
+	if err == nil {
+		*e = CVSS20ReportConfidence(s)
+	}
+	return err
+}
+
+// CVSS20TargetDistribution represents the targetDistributionType in CVSS20.
+type CVSS20TargetDistribution string
+
+const (
+	// CVSS20TargetDistributionNone is a constant for "NONE".
+	CVSS20TargetDistributionNone CVSS20TargetDistribution = "NONE"
+	// CVSS20TargetDistributionLow is a constant for "LOW".
+	CVSS20TargetDistributionLow CVSS20TargetDistribution = "LOW"
+	// CVSS20TargetDistributionMedium is a constant for "MEDIUM".
+	CVSS20TargetDistributionMedium CVSS20TargetDistribution = "MEDIUM"
+	// CVSS20TargetDistributionHigh is a constant for "HIGH".
+	CVSS20TargetDistributionHigh CVSS20TargetDistribution = "HIGH"
+	// CVSS20TargetDistributionNotDefined is a constant for "NOT_DEFINED".
+	CVSS20TargetDistributionNotDefined CVSS20TargetDistribution = "NOT_DEFINED"
+)
+
+var cvss20TargetDistributionPattern = alternativesUnmarshal(
+	string(CVSS20TargetDistributionNone),
+	string(CVSS20TargetDistributionLow),
+	string(CVSS20TargetDistributionMedium),
+	string(CVSS20TargetDistributionHigh),
+	string(CVSS20TargetDistributionNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS20TargetDistribution) UnmarshalText(data []byte) error {
+	s, err := cvss20TargetDistributionPattern(data)
+	if err == nil {
+		*e = CVSS20TargetDistribution(s)
+	}
+	return err
+}

--- a/csaf/cvss30enums.go
+++ b/csaf/cvss30enums.go
@@ -1,0 +1,500 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+//
+// THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
+
+package csaf
+
+// CVSS30AttackComplexity represents the attackComplexityType in CVSS30.
+type CVSS30AttackComplexity string
+
+const (
+	// CVSS30AttackComplexityHigh is a constant for "HIGH".
+	CVSS30AttackComplexityHigh CVSS30AttackComplexity = "HIGH"
+	// CVSS30AttackComplexityLow is a constant for "LOW".
+	CVSS30AttackComplexityLow CVSS30AttackComplexity = "LOW"
+)
+
+var cvss30AttackComplexityPattern = alternativesUnmarshal(
+	string(CVSS30AttackComplexityHigh),
+	string(CVSS30AttackComplexityLow),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30AttackComplexity) UnmarshalText(data []byte) error {
+	s, err := cvss30AttackComplexityPattern(data)
+	if err == nil {
+		*e = CVSS30AttackComplexity(s)
+	}
+	return err
+}
+
+// CVSS30AttackVector represents the attackVectorType in CVSS30.
+type CVSS30AttackVector string
+
+const (
+	// CVSS30AttackVectorNetwork is a constant for "NETWORK".
+	CVSS30AttackVectorNetwork CVSS30AttackVector = "NETWORK"
+	// CVSS30AttackVectorAdjacentNetwork is a constant for "ADJACENT_NETWORK".
+	CVSS30AttackVectorAdjacentNetwork CVSS30AttackVector = "ADJACENT_NETWORK"
+	// CVSS30AttackVectorLocal is a constant for "LOCAL".
+	CVSS30AttackVectorLocal CVSS30AttackVector = "LOCAL"
+	// CVSS30AttackVectorPhysical is a constant for "PHYSICAL".
+	CVSS30AttackVectorPhysical CVSS30AttackVector = "PHYSICAL"
+)
+
+var cvss30AttackVectorPattern = alternativesUnmarshal(
+	string(CVSS30AttackVectorNetwork),
+	string(CVSS30AttackVectorAdjacentNetwork),
+	string(CVSS30AttackVectorLocal),
+	string(CVSS30AttackVectorPhysical),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30AttackVector) UnmarshalText(data []byte) error {
+	s, err := cvss30AttackVectorPattern(data)
+	if err == nil {
+		*e = CVSS30AttackVector(s)
+	}
+	return err
+}
+
+// CVSS30CiaRequirement represents the ciaRequirementType in CVSS30.
+type CVSS30CiaRequirement string
+
+const (
+	// CVSS30CiaRequirementLow is a constant for "LOW".
+	CVSS30CiaRequirementLow CVSS30CiaRequirement = "LOW"
+	// CVSS30CiaRequirementMedium is a constant for "MEDIUM".
+	CVSS30CiaRequirementMedium CVSS30CiaRequirement = "MEDIUM"
+	// CVSS30CiaRequirementHigh is a constant for "HIGH".
+	CVSS30CiaRequirementHigh CVSS30CiaRequirement = "HIGH"
+	// CVSS30CiaRequirementNotDefined is a constant for "NOT_DEFINED".
+	CVSS30CiaRequirementNotDefined CVSS30CiaRequirement = "NOT_DEFINED"
+)
+
+var cvss30CiaRequirementPattern = alternativesUnmarshal(
+	string(CVSS30CiaRequirementLow),
+	string(CVSS30CiaRequirementMedium),
+	string(CVSS30CiaRequirementHigh),
+	string(CVSS30CiaRequirementNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30CiaRequirement) UnmarshalText(data []byte) error {
+	s, err := cvss30CiaRequirementPattern(data)
+	if err == nil {
+		*e = CVSS30CiaRequirement(s)
+	}
+	return err
+}
+
+// CVSS30Cia represents the ciaType in CVSS30.
+type CVSS30Cia string
+
+const (
+	// CVSS30CiaNone is a constant for "NONE".
+	CVSS30CiaNone CVSS30Cia = "NONE"
+	// CVSS30CiaLow is a constant for "LOW".
+	CVSS30CiaLow CVSS30Cia = "LOW"
+	// CVSS30CiaHigh is a constant for "HIGH".
+	CVSS30CiaHigh CVSS30Cia = "HIGH"
+)
+
+var cvss30CiaPattern = alternativesUnmarshal(
+	string(CVSS30CiaNone),
+	string(CVSS30CiaLow),
+	string(CVSS30CiaHigh),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30Cia) UnmarshalText(data []byte) error {
+	s, err := cvss30CiaPattern(data)
+	if err == nil {
+		*e = CVSS30Cia(s)
+	}
+	return err
+}
+
+// CVSS30Confidence represents the confidenceType in CVSS30.
+type CVSS30Confidence string
+
+const (
+	// CVSS30ConfidenceUnknown is a constant for "UNKNOWN".
+	CVSS30ConfidenceUnknown CVSS30Confidence = "UNKNOWN"
+	// CVSS30ConfidenceReasonable is a constant for "REASONABLE".
+	CVSS30ConfidenceReasonable CVSS30Confidence = "REASONABLE"
+	// CVSS30ConfidenceConfirmed is a constant for "CONFIRMED".
+	CVSS30ConfidenceConfirmed CVSS30Confidence = "CONFIRMED"
+	// CVSS30ConfidenceNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ConfidenceNotDefined CVSS30Confidence = "NOT_DEFINED"
+)
+
+var cvss30ConfidencePattern = alternativesUnmarshal(
+	string(CVSS30ConfidenceUnknown),
+	string(CVSS30ConfidenceReasonable),
+	string(CVSS30ConfidenceConfirmed),
+	string(CVSS30ConfidenceNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30Confidence) UnmarshalText(data []byte) error {
+	s, err := cvss30ConfidencePattern(data)
+	if err == nil {
+		*e = CVSS30Confidence(s)
+	}
+	return err
+}
+
+// CVSS30ExploitCodeMaturity represents the exploitCodeMaturityType in CVSS30.
+type CVSS30ExploitCodeMaturity string
+
+const (
+	// CVSS30ExploitCodeMaturityUnproven is a constant for "UNPROVEN".
+	CVSS30ExploitCodeMaturityUnproven CVSS30ExploitCodeMaturity = "UNPROVEN"
+	// CVSS30ExploitCodeMaturityProofOfConcept is a constant for "PROOF_OF_CONCEPT".
+	CVSS30ExploitCodeMaturityProofOfConcept CVSS30ExploitCodeMaturity = "PROOF_OF_CONCEPT"
+	// CVSS30ExploitCodeMaturityFunctional is a constant for "FUNCTIONAL".
+	CVSS30ExploitCodeMaturityFunctional CVSS30ExploitCodeMaturity = "FUNCTIONAL"
+	// CVSS30ExploitCodeMaturityHigh is a constant for "HIGH".
+	CVSS30ExploitCodeMaturityHigh CVSS30ExploitCodeMaturity = "HIGH"
+	// CVSS30ExploitCodeMaturityNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ExploitCodeMaturityNotDefined CVSS30ExploitCodeMaturity = "NOT_DEFINED"
+)
+
+var cvss30ExploitCodeMaturityPattern = alternativesUnmarshal(
+	string(CVSS30ExploitCodeMaturityUnproven),
+	string(CVSS30ExploitCodeMaturityProofOfConcept),
+	string(CVSS30ExploitCodeMaturityFunctional),
+	string(CVSS30ExploitCodeMaturityHigh),
+	string(CVSS30ExploitCodeMaturityNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ExploitCodeMaturity) UnmarshalText(data []byte) error {
+	s, err := cvss30ExploitCodeMaturityPattern(data)
+	if err == nil {
+		*e = CVSS30ExploitCodeMaturity(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedAttackComplexity represents the modifiedAttackComplexityType in CVSS30.
+type CVSS30ModifiedAttackComplexity string
+
+const (
+	// CVSS30ModifiedAttackComplexityHigh is a constant for "HIGH".
+	CVSS30ModifiedAttackComplexityHigh CVSS30ModifiedAttackComplexity = "HIGH"
+	// CVSS30ModifiedAttackComplexityLow is a constant for "LOW".
+	CVSS30ModifiedAttackComplexityLow CVSS30ModifiedAttackComplexity = "LOW"
+	// CVSS30ModifiedAttackComplexityNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedAttackComplexityNotDefined CVSS30ModifiedAttackComplexity = "NOT_DEFINED"
+)
+
+var cvss30ModifiedAttackComplexityPattern = alternativesUnmarshal(
+	string(CVSS30ModifiedAttackComplexityHigh),
+	string(CVSS30ModifiedAttackComplexityLow),
+	string(CVSS30ModifiedAttackComplexityNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedAttackComplexity) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedAttackComplexityPattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedAttackComplexity(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedAttackVector represents the modifiedAttackVectorType in CVSS30.
+type CVSS30ModifiedAttackVector string
+
+const (
+	// CVSS30ModifiedAttackVectorNetwork is a constant for "NETWORK".
+	CVSS30ModifiedAttackVectorNetwork CVSS30ModifiedAttackVector = "NETWORK"
+	// CVSS30ModifiedAttackVectorAdjacentNetwork is a constant for "ADJACENT_NETWORK".
+	CVSS30ModifiedAttackVectorAdjacentNetwork CVSS30ModifiedAttackVector = "ADJACENT_NETWORK"
+	// CVSS30ModifiedAttackVectorLocal is a constant for "LOCAL".
+	CVSS30ModifiedAttackVectorLocal CVSS30ModifiedAttackVector = "LOCAL"
+	// CVSS30ModifiedAttackVectorPhysical is a constant for "PHYSICAL".
+	CVSS30ModifiedAttackVectorPhysical CVSS30ModifiedAttackVector = "PHYSICAL"
+	// CVSS30ModifiedAttackVectorNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedAttackVectorNotDefined CVSS30ModifiedAttackVector = "NOT_DEFINED"
+)
+
+var cvss30ModifiedAttackVectorPattern = alternativesUnmarshal(
+	string(CVSS30ModifiedAttackVectorNetwork),
+	string(CVSS30ModifiedAttackVectorAdjacentNetwork),
+	string(CVSS30ModifiedAttackVectorLocal),
+	string(CVSS30ModifiedAttackVectorPhysical),
+	string(CVSS30ModifiedAttackVectorNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedAttackVector) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedAttackVectorPattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedAttackVector(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedCia represents the modifiedCiaType in CVSS30.
+type CVSS30ModifiedCia string
+
+const (
+	// CVSS30ModifiedCiaNone is a constant for "NONE".
+	CVSS30ModifiedCiaNone CVSS30ModifiedCia = "NONE"
+	// CVSS30ModifiedCiaLow is a constant for "LOW".
+	CVSS30ModifiedCiaLow CVSS30ModifiedCia = "LOW"
+	// CVSS30ModifiedCiaHigh is a constant for "HIGH".
+	CVSS30ModifiedCiaHigh CVSS30ModifiedCia = "HIGH"
+	// CVSS30ModifiedCiaNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedCiaNotDefined CVSS30ModifiedCia = "NOT_DEFINED"
+)
+
+var cvss30ModifiedCiaPattern = alternativesUnmarshal(
+	string(CVSS30ModifiedCiaNone),
+	string(CVSS30ModifiedCiaLow),
+	string(CVSS30ModifiedCiaHigh),
+	string(CVSS30ModifiedCiaNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedCia) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedCiaPattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedCia(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedPrivilegesRequired represents the modifiedPrivilegesRequiredType in CVSS30.
+type CVSS30ModifiedPrivilegesRequired string
+
+const (
+	// CVSS30ModifiedPrivilegesRequiredHigh is a constant for "HIGH".
+	CVSS30ModifiedPrivilegesRequiredHigh CVSS30ModifiedPrivilegesRequired = "HIGH"
+	// CVSS30ModifiedPrivilegesRequiredLow is a constant for "LOW".
+	CVSS30ModifiedPrivilegesRequiredLow CVSS30ModifiedPrivilegesRequired = "LOW"
+	// CVSS30ModifiedPrivilegesRequiredNone is a constant for "NONE".
+	CVSS30ModifiedPrivilegesRequiredNone CVSS30ModifiedPrivilegesRequired = "NONE"
+	// CVSS30ModifiedPrivilegesRequiredNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedPrivilegesRequiredNotDefined CVSS30ModifiedPrivilegesRequired = "NOT_DEFINED"
+)
+
+var cvss30ModifiedPrivilegesRequiredPattern = alternativesUnmarshal(
+	string(CVSS30ModifiedPrivilegesRequiredHigh),
+	string(CVSS30ModifiedPrivilegesRequiredLow),
+	string(CVSS30ModifiedPrivilegesRequiredNone),
+	string(CVSS30ModifiedPrivilegesRequiredNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedPrivilegesRequired) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedPrivilegesRequiredPattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedPrivilegesRequired(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedScope represents the modifiedScopeType in CVSS30.
+type CVSS30ModifiedScope string
+
+const (
+	// CVSS30ModifiedScopeUnchanged is a constant for "UNCHANGED".
+	CVSS30ModifiedScopeUnchanged CVSS30ModifiedScope = "UNCHANGED"
+	// CVSS30ModifiedScopeChanged is a constant for "CHANGED".
+	CVSS30ModifiedScopeChanged CVSS30ModifiedScope = "CHANGED"
+	// CVSS30ModifiedScopeNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedScopeNotDefined CVSS30ModifiedScope = "NOT_DEFINED"
+)
+
+var cvss30ModifiedScopePattern = alternativesUnmarshal(
+	string(CVSS30ModifiedScopeUnchanged),
+	string(CVSS30ModifiedScopeChanged),
+	string(CVSS30ModifiedScopeNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedScope) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedScopePattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedScope(s)
+	}
+	return err
+}
+
+// CVSS30ModifiedUserInteraction represents the modifiedUserInteractionType in CVSS30.
+type CVSS30ModifiedUserInteraction string
+
+const (
+	// CVSS30ModifiedUserInteractionNone is a constant for "NONE".
+	CVSS30ModifiedUserInteractionNone CVSS30ModifiedUserInteraction = "NONE"
+	// CVSS30ModifiedUserInteractionRequired is a constant for "REQUIRED".
+	CVSS30ModifiedUserInteractionRequired CVSS30ModifiedUserInteraction = "REQUIRED"
+	// CVSS30ModifiedUserInteractionNotDefined is a constant for "NOT_DEFINED".
+	CVSS30ModifiedUserInteractionNotDefined CVSS30ModifiedUserInteraction = "NOT_DEFINED"
+)
+
+var cvss30ModifiedUserInteractionPattern = alternativesUnmarshal(
+	string(CVSS30ModifiedUserInteractionNone),
+	string(CVSS30ModifiedUserInteractionRequired),
+	string(CVSS30ModifiedUserInteractionNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30ModifiedUserInteraction) UnmarshalText(data []byte) error {
+	s, err := cvss30ModifiedUserInteractionPattern(data)
+	if err == nil {
+		*e = CVSS30ModifiedUserInteraction(s)
+	}
+	return err
+}
+
+// CVSS30PrivilegesRequired represents the privilegesRequiredType in CVSS30.
+type CVSS30PrivilegesRequired string
+
+const (
+	// CVSS30PrivilegesRequiredHigh is a constant for "HIGH".
+	CVSS30PrivilegesRequiredHigh CVSS30PrivilegesRequired = "HIGH"
+	// CVSS30PrivilegesRequiredLow is a constant for "LOW".
+	CVSS30PrivilegesRequiredLow CVSS30PrivilegesRequired = "LOW"
+	// CVSS30PrivilegesRequiredNone is a constant for "NONE".
+	CVSS30PrivilegesRequiredNone CVSS30PrivilegesRequired = "NONE"
+)
+
+var cvss30PrivilegesRequiredPattern = alternativesUnmarshal(
+	string(CVSS30PrivilegesRequiredHigh),
+	string(CVSS30PrivilegesRequiredLow),
+	string(CVSS30PrivilegesRequiredNone),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30PrivilegesRequired) UnmarshalText(data []byte) error {
+	s, err := cvss30PrivilegesRequiredPattern(data)
+	if err == nil {
+		*e = CVSS30PrivilegesRequired(s)
+	}
+	return err
+}
+
+// CVSS30RemediationLevel represents the remediationLevelType in CVSS30.
+type CVSS30RemediationLevel string
+
+const (
+	// CVSS30RemediationLevelOfficialFix is a constant for "OFFICIAL_FIX".
+	CVSS30RemediationLevelOfficialFix CVSS30RemediationLevel = "OFFICIAL_FIX"
+	// CVSS30RemediationLevelTemporaryFix is a constant for "TEMPORARY_FIX".
+	CVSS30RemediationLevelTemporaryFix CVSS30RemediationLevel = "TEMPORARY_FIX"
+	// CVSS30RemediationLevelWorkaround is a constant for "WORKAROUND".
+	CVSS30RemediationLevelWorkaround CVSS30RemediationLevel = "WORKAROUND"
+	// CVSS30RemediationLevelUnavailable is a constant for "UNAVAILABLE".
+	CVSS30RemediationLevelUnavailable CVSS30RemediationLevel = "UNAVAILABLE"
+	// CVSS30RemediationLevelNotDefined is a constant for "NOT_DEFINED".
+	CVSS30RemediationLevelNotDefined CVSS30RemediationLevel = "NOT_DEFINED"
+)
+
+var cvss30RemediationLevelPattern = alternativesUnmarshal(
+	string(CVSS30RemediationLevelOfficialFix),
+	string(CVSS30RemediationLevelTemporaryFix),
+	string(CVSS30RemediationLevelWorkaround),
+	string(CVSS30RemediationLevelUnavailable),
+	string(CVSS30RemediationLevelNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30RemediationLevel) UnmarshalText(data []byte) error {
+	s, err := cvss30RemediationLevelPattern(data)
+	if err == nil {
+		*e = CVSS30RemediationLevel(s)
+	}
+	return err
+}
+
+// CVSS30Scope represents the scopeType in CVSS30.
+type CVSS30Scope string
+
+const (
+	// CVSS30ScopeUnchanged is a constant for "UNCHANGED".
+	CVSS30ScopeUnchanged CVSS30Scope = "UNCHANGED"
+	// CVSS30ScopeChanged is a constant for "CHANGED".
+	CVSS30ScopeChanged CVSS30Scope = "CHANGED"
+)
+
+var cvss30ScopePattern = alternativesUnmarshal(
+	string(CVSS30ScopeUnchanged),
+	string(CVSS30ScopeChanged),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30Scope) UnmarshalText(data []byte) error {
+	s, err := cvss30ScopePattern(data)
+	if err == nil {
+		*e = CVSS30Scope(s)
+	}
+	return err
+}
+
+// CVSS30Severity represents the severityType in CVSS30.
+type CVSS30Severity string
+
+const (
+	// CVSS30SeverityNone is a constant for "NONE".
+	CVSS30SeverityNone CVSS30Severity = "NONE"
+	// CVSS30SeverityLow is a constant for "LOW".
+	CVSS30SeverityLow CVSS30Severity = "LOW"
+	// CVSS30SeverityMedium is a constant for "MEDIUM".
+	CVSS30SeverityMedium CVSS30Severity = "MEDIUM"
+	// CVSS30SeverityHigh is a constant for "HIGH".
+	CVSS30SeverityHigh CVSS30Severity = "HIGH"
+	// CVSS30SeverityCritical is a constant for "CRITICAL".
+	CVSS30SeverityCritical CVSS30Severity = "CRITICAL"
+)
+
+var cvss30SeverityPattern = alternativesUnmarshal(
+	string(CVSS30SeverityNone),
+	string(CVSS30SeverityLow),
+	string(CVSS30SeverityMedium),
+	string(CVSS30SeverityHigh),
+	string(CVSS30SeverityCritical),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30Severity) UnmarshalText(data []byte) error {
+	s, err := cvss30SeverityPattern(data)
+	if err == nil {
+		*e = CVSS30Severity(s)
+	}
+	return err
+}
+
+// CVSS30UserInteraction represents the userInteractionType in CVSS30.
+type CVSS30UserInteraction string
+
+const (
+	// CVSS30UserInteractionNone is a constant for "NONE".
+	CVSS30UserInteractionNone CVSS30UserInteraction = "NONE"
+	// CVSS30UserInteractionRequired is a constant for "REQUIRED".
+	CVSS30UserInteractionRequired CVSS30UserInteraction = "REQUIRED"
+)
+
+var cvss30UserInteractionPattern = alternativesUnmarshal(
+	string(CVSS30UserInteractionNone),
+	string(CVSS30UserInteractionRequired),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS30UserInteraction) UnmarshalText(data []byte) error {
+	s, err := cvss30UserInteractionPattern(data)
+	if err == nil {
+		*e = CVSS30UserInteraction(s)
+	}
+	return err
+}

--- a/csaf/cvss31enums.go
+++ b/csaf/cvss31enums.go
@@ -1,0 +1,500 @@
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+//
+// THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
+
+package csaf
+
+// CVSS31AttackComplexity represents the attackComplexityType in CVSS31.
+type CVSS31AttackComplexity string
+
+const (
+	// CVSS31AttackComplexityHigh is a constant for "HIGH".
+	CVSS31AttackComplexityHigh CVSS31AttackComplexity = "HIGH"
+	// CVSS31AttackComplexityLow is a constant for "LOW".
+	CVSS31AttackComplexityLow CVSS31AttackComplexity = "LOW"
+)
+
+var cvss31AttackComplexityPattern = alternativesUnmarshal(
+	string(CVSS31AttackComplexityHigh),
+	string(CVSS31AttackComplexityLow),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31AttackComplexity) UnmarshalText(data []byte) error {
+	s, err := cvss31AttackComplexityPattern(data)
+	if err == nil {
+		*e = CVSS31AttackComplexity(s)
+	}
+	return err
+}
+
+// CVSS31AttackVector represents the attackVectorType in CVSS31.
+type CVSS31AttackVector string
+
+const (
+	// CVSS31AttackVectorNetwork is a constant for "NETWORK".
+	CVSS31AttackVectorNetwork CVSS31AttackVector = "NETWORK"
+	// CVSS31AttackVectorAdjacentNetwork is a constant for "ADJACENT_NETWORK".
+	CVSS31AttackVectorAdjacentNetwork CVSS31AttackVector = "ADJACENT_NETWORK"
+	// CVSS31AttackVectorLocal is a constant for "LOCAL".
+	CVSS31AttackVectorLocal CVSS31AttackVector = "LOCAL"
+	// CVSS31AttackVectorPhysical is a constant for "PHYSICAL".
+	CVSS31AttackVectorPhysical CVSS31AttackVector = "PHYSICAL"
+)
+
+var cvss31AttackVectorPattern = alternativesUnmarshal(
+	string(CVSS31AttackVectorNetwork),
+	string(CVSS31AttackVectorAdjacentNetwork),
+	string(CVSS31AttackVectorLocal),
+	string(CVSS31AttackVectorPhysical),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31AttackVector) UnmarshalText(data []byte) error {
+	s, err := cvss31AttackVectorPattern(data)
+	if err == nil {
+		*e = CVSS31AttackVector(s)
+	}
+	return err
+}
+
+// CVSS31CiaRequirement represents the ciaRequirementType in CVSS31.
+type CVSS31CiaRequirement string
+
+const (
+	// CVSS31CiaRequirementLow is a constant for "LOW".
+	CVSS31CiaRequirementLow CVSS31CiaRequirement = "LOW"
+	// CVSS31CiaRequirementMedium is a constant for "MEDIUM".
+	CVSS31CiaRequirementMedium CVSS31CiaRequirement = "MEDIUM"
+	// CVSS31CiaRequirementHigh is a constant for "HIGH".
+	CVSS31CiaRequirementHigh CVSS31CiaRequirement = "HIGH"
+	// CVSS31CiaRequirementNotDefined is a constant for "NOT_DEFINED".
+	CVSS31CiaRequirementNotDefined CVSS31CiaRequirement = "NOT_DEFINED"
+)
+
+var cvss31CiaRequirementPattern = alternativesUnmarshal(
+	string(CVSS31CiaRequirementLow),
+	string(CVSS31CiaRequirementMedium),
+	string(CVSS31CiaRequirementHigh),
+	string(CVSS31CiaRequirementNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31CiaRequirement) UnmarshalText(data []byte) error {
+	s, err := cvss31CiaRequirementPattern(data)
+	if err == nil {
+		*e = CVSS31CiaRequirement(s)
+	}
+	return err
+}
+
+// CVSS31Cia represents the ciaType in CVSS31.
+type CVSS31Cia string
+
+const (
+	// CVSS31CiaNone is a constant for "NONE".
+	CVSS31CiaNone CVSS31Cia = "NONE"
+	// CVSS31CiaLow is a constant for "LOW".
+	CVSS31CiaLow CVSS31Cia = "LOW"
+	// CVSS31CiaHigh is a constant for "HIGH".
+	CVSS31CiaHigh CVSS31Cia = "HIGH"
+)
+
+var cvss31CiaPattern = alternativesUnmarshal(
+	string(CVSS31CiaNone),
+	string(CVSS31CiaLow),
+	string(CVSS31CiaHigh),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31Cia) UnmarshalText(data []byte) error {
+	s, err := cvss31CiaPattern(data)
+	if err == nil {
+		*e = CVSS31Cia(s)
+	}
+	return err
+}
+
+// CVSS31Confidence represents the confidenceType in CVSS31.
+type CVSS31Confidence string
+
+const (
+	// CVSS31ConfidenceUnknown is a constant for "UNKNOWN".
+	CVSS31ConfidenceUnknown CVSS31Confidence = "UNKNOWN"
+	// CVSS31ConfidenceReasonable is a constant for "REASONABLE".
+	CVSS31ConfidenceReasonable CVSS31Confidence = "REASONABLE"
+	// CVSS31ConfidenceConfirmed is a constant for "CONFIRMED".
+	CVSS31ConfidenceConfirmed CVSS31Confidence = "CONFIRMED"
+	// CVSS31ConfidenceNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ConfidenceNotDefined CVSS31Confidence = "NOT_DEFINED"
+)
+
+var cvss31ConfidencePattern = alternativesUnmarshal(
+	string(CVSS31ConfidenceUnknown),
+	string(CVSS31ConfidenceReasonable),
+	string(CVSS31ConfidenceConfirmed),
+	string(CVSS31ConfidenceNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31Confidence) UnmarshalText(data []byte) error {
+	s, err := cvss31ConfidencePattern(data)
+	if err == nil {
+		*e = CVSS31Confidence(s)
+	}
+	return err
+}
+
+// CVSS31ExploitCodeMaturity represents the exploitCodeMaturityType in CVSS31.
+type CVSS31ExploitCodeMaturity string
+
+const (
+	// CVSS31ExploitCodeMaturityUnproven is a constant for "UNPROVEN".
+	CVSS31ExploitCodeMaturityUnproven CVSS31ExploitCodeMaturity = "UNPROVEN"
+	// CVSS31ExploitCodeMaturityProofOfConcept is a constant for "PROOF_OF_CONCEPT".
+	CVSS31ExploitCodeMaturityProofOfConcept CVSS31ExploitCodeMaturity = "PROOF_OF_CONCEPT"
+	// CVSS31ExploitCodeMaturityFunctional is a constant for "FUNCTIONAL".
+	CVSS31ExploitCodeMaturityFunctional CVSS31ExploitCodeMaturity = "FUNCTIONAL"
+	// CVSS31ExploitCodeMaturityHigh is a constant for "HIGH".
+	CVSS31ExploitCodeMaturityHigh CVSS31ExploitCodeMaturity = "HIGH"
+	// CVSS31ExploitCodeMaturityNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ExploitCodeMaturityNotDefined CVSS31ExploitCodeMaturity = "NOT_DEFINED"
+)
+
+var cvss31ExploitCodeMaturityPattern = alternativesUnmarshal(
+	string(CVSS31ExploitCodeMaturityUnproven),
+	string(CVSS31ExploitCodeMaturityProofOfConcept),
+	string(CVSS31ExploitCodeMaturityFunctional),
+	string(CVSS31ExploitCodeMaturityHigh),
+	string(CVSS31ExploitCodeMaturityNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ExploitCodeMaturity) UnmarshalText(data []byte) error {
+	s, err := cvss31ExploitCodeMaturityPattern(data)
+	if err == nil {
+		*e = CVSS31ExploitCodeMaturity(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedAttackComplexity represents the modifiedAttackComplexityType in CVSS31.
+type CVSS31ModifiedAttackComplexity string
+
+const (
+	// CVSS31ModifiedAttackComplexityHigh is a constant for "HIGH".
+	CVSS31ModifiedAttackComplexityHigh CVSS31ModifiedAttackComplexity = "HIGH"
+	// CVSS31ModifiedAttackComplexityLow is a constant for "LOW".
+	CVSS31ModifiedAttackComplexityLow CVSS31ModifiedAttackComplexity = "LOW"
+	// CVSS31ModifiedAttackComplexityNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedAttackComplexityNotDefined CVSS31ModifiedAttackComplexity = "NOT_DEFINED"
+)
+
+var cvss31ModifiedAttackComplexityPattern = alternativesUnmarshal(
+	string(CVSS31ModifiedAttackComplexityHigh),
+	string(CVSS31ModifiedAttackComplexityLow),
+	string(CVSS31ModifiedAttackComplexityNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedAttackComplexity) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedAttackComplexityPattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedAttackComplexity(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedAttackVector represents the modifiedAttackVectorType in CVSS31.
+type CVSS31ModifiedAttackVector string
+
+const (
+	// CVSS31ModifiedAttackVectorNetwork is a constant for "NETWORK".
+	CVSS31ModifiedAttackVectorNetwork CVSS31ModifiedAttackVector = "NETWORK"
+	// CVSS31ModifiedAttackVectorAdjacentNetwork is a constant for "ADJACENT_NETWORK".
+	CVSS31ModifiedAttackVectorAdjacentNetwork CVSS31ModifiedAttackVector = "ADJACENT_NETWORK"
+	// CVSS31ModifiedAttackVectorLocal is a constant for "LOCAL".
+	CVSS31ModifiedAttackVectorLocal CVSS31ModifiedAttackVector = "LOCAL"
+	// CVSS31ModifiedAttackVectorPhysical is a constant for "PHYSICAL".
+	CVSS31ModifiedAttackVectorPhysical CVSS31ModifiedAttackVector = "PHYSICAL"
+	// CVSS31ModifiedAttackVectorNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedAttackVectorNotDefined CVSS31ModifiedAttackVector = "NOT_DEFINED"
+)
+
+var cvss31ModifiedAttackVectorPattern = alternativesUnmarshal(
+	string(CVSS31ModifiedAttackVectorNetwork),
+	string(CVSS31ModifiedAttackVectorAdjacentNetwork),
+	string(CVSS31ModifiedAttackVectorLocal),
+	string(CVSS31ModifiedAttackVectorPhysical),
+	string(CVSS31ModifiedAttackVectorNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedAttackVector) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedAttackVectorPattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedAttackVector(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedCia represents the modifiedCiaType in CVSS31.
+type CVSS31ModifiedCia string
+
+const (
+	// CVSS31ModifiedCiaNone is a constant for "NONE".
+	CVSS31ModifiedCiaNone CVSS31ModifiedCia = "NONE"
+	// CVSS31ModifiedCiaLow is a constant for "LOW".
+	CVSS31ModifiedCiaLow CVSS31ModifiedCia = "LOW"
+	// CVSS31ModifiedCiaHigh is a constant for "HIGH".
+	CVSS31ModifiedCiaHigh CVSS31ModifiedCia = "HIGH"
+	// CVSS31ModifiedCiaNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedCiaNotDefined CVSS31ModifiedCia = "NOT_DEFINED"
+)
+
+var cvss31ModifiedCiaPattern = alternativesUnmarshal(
+	string(CVSS31ModifiedCiaNone),
+	string(CVSS31ModifiedCiaLow),
+	string(CVSS31ModifiedCiaHigh),
+	string(CVSS31ModifiedCiaNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedCia) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedCiaPattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedCia(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedPrivilegesRequired represents the modifiedPrivilegesRequiredType in CVSS31.
+type CVSS31ModifiedPrivilegesRequired string
+
+const (
+	// CVSS31ModifiedPrivilegesRequiredHigh is a constant for "HIGH".
+	CVSS31ModifiedPrivilegesRequiredHigh CVSS31ModifiedPrivilegesRequired = "HIGH"
+	// CVSS31ModifiedPrivilegesRequiredLow is a constant for "LOW".
+	CVSS31ModifiedPrivilegesRequiredLow CVSS31ModifiedPrivilegesRequired = "LOW"
+	// CVSS31ModifiedPrivilegesRequiredNone is a constant for "NONE".
+	CVSS31ModifiedPrivilegesRequiredNone CVSS31ModifiedPrivilegesRequired = "NONE"
+	// CVSS31ModifiedPrivilegesRequiredNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedPrivilegesRequiredNotDefined CVSS31ModifiedPrivilegesRequired = "NOT_DEFINED"
+)
+
+var cvss31ModifiedPrivilegesRequiredPattern = alternativesUnmarshal(
+	string(CVSS31ModifiedPrivilegesRequiredHigh),
+	string(CVSS31ModifiedPrivilegesRequiredLow),
+	string(CVSS31ModifiedPrivilegesRequiredNone),
+	string(CVSS31ModifiedPrivilegesRequiredNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedPrivilegesRequired) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedPrivilegesRequiredPattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedPrivilegesRequired(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedScope represents the modifiedScopeType in CVSS31.
+type CVSS31ModifiedScope string
+
+const (
+	// CVSS31ModifiedScopeUnchanged is a constant for "UNCHANGED".
+	CVSS31ModifiedScopeUnchanged CVSS31ModifiedScope = "UNCHANGED"
+	// CVSS31ModifiedScopeChanged is a constant for "CHANGED".
+	CVSS31ModifiedScopeChanged CVSS31ModifiedScope = "CHANGED"
+	// CVSS31ModifiedScopeNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedScopeNotDefined CVSS31ModifiedScope = "NOT_DEFINED"
+)
+
+var cvss31ModifiedScopePattern = alternativesUnmarshal(
+	string(CVSS31ModifiedScopeUnchanged),
+	string(CVSS31ModifiedScopeChanged),
+	string(CVSS31ModifiedScopeNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedScope) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedScopePattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedScope(s)
+	}
+	return err
+}
+
+// CVSS31ModifiedUserInteraction represents the modifiedUserInteractionType in CVSS31.
+type CVSS31ModifiedUserInteraction string
+
+const (
+	// CVSS31ModifiedUserInteractionNone is a constant for "NONE".
+	CVSS31ModifiedUserInteractionNone CVSS31ModifiedUserInteraction = "NONE"
+	// CVSS31ModifiedUserInteractionRequired is a constant for "REQUIRED".
+	CVSS31ModifiedUserInteractionRequired CVSS31ModifiedUserInteraction = "REQUIRED"
+	// CVSS31ModifiedUserInteractionNotDefined is a constant for "NOT_DEFINED".
+	CVSS31ModifiedUserInteractionNotDefined CVSS31ModifiedUserInteraction = "NOT_DEFINED"
+)
+
+var cvss31ModifiedUserInteractionPattern = alternativesUnmarshal(
+	string(CVSS31ModifiedUserInteractionNone),
+	string(CVSS31ModifiedUserInteractionRequired),
+	string(CVSS31ModifiedUserInteractionNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31ModifiedUserInteraction) UnmarshalText(data []byte) error {
+	s, err := cvss31ModifiedUserInteractionPattern(data)
+	if err == nil {
+		*e = CVSS31ModifiedUserInteraction(s)
+	}
+	return err
+}
+
+// CVSS31PrivilegesRequired represents the privilegesRequiredType in CVSS31.
+type CVSS31PrivilegesRequired string
+
+const (
+	// CVSS31PrivilegesRequiredHigh is a constant for "HIGH".
+	CVSS31PrivilegesRequiredHigh CVSS31PrivilegesRequired = "HIGH"
+	// CVSS31PrivilegesRequiredLow is a constant for "LOW".
+	CVSS31PrivilegesRequiredLow CVSS31PrivilegesRequired = "LOW"
+	// CVSS31PrivilegesRequiredNone is a constant for "NONE".
+	CVSS31PrivilegesRequiredNone CVSS31PrivilegesRequired = "NONE"
+)
+
+var cvss31PrivilegesRequiredPattern = alternativesUnmarshal(
+	string(CVSS31PrivilegesRequiredHigh),
+	string(CVSS31PrivilegesRequiredLow),
+	string(CVSS31PrivilegesRequiredNone),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31PrivilegesRequired) UnmarshalText(data []byte) error {
+	s, err := cvss31PrivilegesRequiredPattern(data)
+	if err == nil {
+		*e = CVSS31PrivilegesRequired(s)
+	}
+	return err
+}
+
+// CVSS31RemediationLevel represents the remediationLevelType in CVSS31.
+type CVSS31RemediationLevel string
+
+const (
+	// CVSS31RemediationLevelOfficialFix is a constant for "OFFICIAL_FIX".
+	CVSS31RemediationLevelOfficialFix CVSS31RemediationLevel = "OFFICIAL_FIX"
+	// CVSS31RemediationLevelTemporaryFix is a constant for "TEMPORARY_FIX".
+	CVSS31RemediationLevelTemporaryFix CVSS31RemediationLevel = "TEMPORARY_FIX"
+	// CVSS31RemediationLevelWorkaround is a constant for "WORKAROUND".
+	CVSS31RemediationLevelWorkaround CVSS31RemediationLevel = "WORKAROUND"
+	// CVSS31RemediationLevelUnavailable is a constant for "UNAVAILABLE".
+	CVSS31RemediationLevelUnavailable CVSS31RemediationLevel = "UNAVAILABLE"
+	// CVSS31RemediationLevelNotDefined is a constant for "NOT_DEFINED".
+	CVSS31RemediationLevelNotDefined CVSS31RemediationLevel = "NOT_DEFINED"
+)
+
+var cvss31RemediationLevelPattern = alternativesUnmarshal(
+	string(CVSS31RemediationLevelOfficialFix),
+	string(CVSS31RemediationLevelTemporaryFix),
+	string(CVSS31RemediationLevelWorkaround),
+	string(CVSS31RemediationLevelUnavailable),
+	string(CVSS31RemediationLevelNotDefined),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31RemediationLevel) UnmarshalText(data []byte) error {
+	s, err := cvss31RemediationLevelPattern(data)
+	if err == nil {
+		*e = CVSS31RemediationLevel(s)
+	}
+	return err
+}
+
+// CVSS31Scope represents the scopeType in CVSS31.
+type CVSS31Scope string
+
+const (
+	// CVSS31ScopeUnchanged is a constant for "UNCHANGED".
+	CVSS31ScopeUnchanged CVSS31Scope = "UNCHANGED"
+	// CVSS31ScopeChanged is a constant for "CHANGED".
+	CVSS31ScopeChanged CVSS31Scope = "CHANGED"
+)
+
+var cvss31ScopePattern = alternativesUnmarshal(
+	string(CVSS31ScopeUnchanged),
+	string(CVSS31ScopeChanged),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31Scope) UnmarshalText(data []byte) error {
+	s, err := cvss31ScopePattern(data)
+	if err == nil {
+		*e = CVSS31Scope(s)
+	}
+	return err
+}
+
+// CVSS31Severity represents the severityType in CVSS31.
+type CVSS31Severity string
+
+const (
+	// CVSS31SeverityNone is a constant for "NONE".
+	CVSS31SeverityNone CVSS31Severity = "NONE"
+	// CVSS31SeverityLow is a constant for "LOW".
+	CVSS31SeverityLow CVSS31Severity = "LOW"
+	// CVSS31SeverityMedium is a constant for "MEDIUM".
+	CVSS31SeverityMedium CVSS31Severity = "MEDIUM"
+	// CVSS31SeverityHigh is a constant for "HIGH".
+	CVSS31SeverityHigh CVSS31Severity = "HIGH"
+	// CVSS31SeverityCritical is a constant for "CRITICAL".
+	CVSS31SeverityCritical CVSS31Severity = "CRITICAL"
+)
+
+var cvss31SeverityPattern = alternativesUnmarshal(
+	string(CVSS31SeverityNone),
+	string(CVSS31SeverityLow),
+	string(CVSS31SeverityMedium),
+	string(CVSS31SeverityHigh),
+	string(CVSS31SeverityCritical),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31Severity) UnmarshalText(data []byte) error {
+	s, err := cvss31SeverityPattern(data)
+	if err == nil {
+		*e = CVSS31Severity(s)
+	}
+	return err
+}
+
+// CVSS31UserInteraction represents the userInteractionType in CVSS31.
+type CVSS31UserInteraction string
+
+const (
+	// CVSS31UserInteractionNone is a constant for "NONE".
+	CVSS31UserInteractionNone CVSS31UserInteraction = "NONE"
+	// CVSS31UserInteractionRequired is a constant for "REQUIRED".
+	CVSS31UserInteractionRequired CVSS31UserInteraction = "REQUIRED"
+)
+
+var cvss31UserInteractionPattern = alternativesUnmarshal(
+	string(CVSS31UserInteractionNone),
+	string(CVSS31UserInteractionRequired),
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *CVSS31UserInteraction) UnmarshalText(data []byte) error {
+	s, err := cvss31UserInteractionPattern(data)
+	if err == nil {
+		*e = CVSS31UserInteraction(s)
+	}
+	return err
+}

--- a/csaf/doc.go
+++ b/csaf/doc.go
@@ -8,3 +8,7 @@
 
 // Package csaf contains the core data models used by the csaf distribution.
 package csaf
+
+//go:generate go run ./generate_cvss_enums.go -o cvss20enums.go -i ./schema/cvss-v2.0.json -p CVSS20
+//go:generate go run ./generate_cvss_enums.go -o cvss30enums.go -i ./schema/cvss-v3.0.json -p CVSS30
+//go:generate go run ./generate_cvss_enums.go -o cvss31enums.go -i ./schema/cvss-v3.1.json -p CVSS31

--- a/csaf/generate_cvss_enums.go
+++ b/csaf/generate_cvss_enums.go
@@ -1,0 +1,152 @@
+//go:build ignore
+
+// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"go/format"
+	"log"
+	"os"
+	"slices"
+	"strings"
+	"text/template"
+)
+
+const tmplText = `// This file is Free Software under the MIT License
+// without warranty, see README.md and LICENSES/MIT.txt for details.
+//
+// SPDX-License-Identifier: MIT
+//
+// SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
+//
+// THIS FILE IS MACHINE GENERATED. EDIT WITH CARE!
+
+package csaf
+
+{{ range $key := .Keys }}
+{{ $def := index $.Definitions $key }}
+// {{ $type := printf "%s%s" $.Prefix (typename $key) }}{{ $type }} represents the {{ $key }} in {{ $.Prefix }}.
+type {{ $type }} string
+const (
+	{{ range $enum := $def.Enum -}}
+	// {{ $type}}{{ symbol $enum }} is a constant for "{{ $enum }}".
+	{{ $type }}{{ symbol $enum }} {{ $type }} = "{{ $enum }}"
+	{{ end }}
+)
+var {{ tolower $.Prefix }}{{ typename $key }}Pattern = alternativesUnmarshal(
+	{{ range $enum := $def.Enum -}}
+	string({{ $type }}{{ symbol $enum }}),
+	{{ end }}
+)
+
+// UnmarshalText implements the [encoding.TextUnmarshaler] interface.
+func (e *{{ $type }}) UnmarshalText(data []byte) error {
+	s, err := {{ tolower $.Prefix }}{{ typename $key }}Pattern(data)
+	if err == nil {
+		*e = {{ $type }}(s)
+	}
+	return err
+}
+{{ end }}
+`
+
+var tmpl = template.Must(template.New("enums").Funcs(funcs).Parse(tmplText))
+
+type definition struct {
+	Type string   `json:"type"`
+	Enum []string `json:"enum"`
+}
+
+type schema struct {
+	Definitions map[string]*definition `json:"definitions"`
+}
+
+var funcs = template.FuncMap{
+	"tolower": strings.ToLower,
+	"symbol": func(s string) string {
+		s = strings.ToLower(s)
+		s = strings.ReplaceAll(s, "_", " ")
+		s = strings.Title(s)
+		s = strings.ReplaceAll(s, " ", "")
+		return s
+	},
+	"typename": func(s string) string {
+		if strings.HasSuffix(s, "Type") {
+			s = s[:len(s)-len("Type")]
+		}
+		s = strings.Title(s)
+		return s
+	},
+}
+
+func loadSchema(filename string) (*schema, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var s schema
+	if err := json.NewDecoder(f).Decode(&s); err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func check(err error) {
+	if err != nil {
+		log.Fatalf("error: %v\n", err)
+	}
+}
+
+func main() {
+	var (
+		input  = flag.String("i", "input", "")
+		output = flag.String("o", "output", "")
+		prefix = flag.String("p", "prefix", "")
+	)
+	flag.Parse()
+	if *input == "" {
+		log.Fatalln("missing schema")
+	}
+	if *output == "" {
+		log.Fatalln("missing output")
+	}
+	if *prefix == "" {
+		log.Fatalln("missing prefix")
+	}
+
+	s, err := loadSchema(*input)
+	check(err)
+
+	defs := make([]string, 0, len(s.Definitions))
+	for k, v := range s.Definitions {
+		if v.Type == "string" && len(v.Enum) > 0 {
+			defs = append(defs, k)
+		}
+	}
+	slices.Sort(defs)
+
+	var source bytes.Buffer
+
+	check(tmpl.Execute(&source, map[string]any{
+		"Prefix":      *prefix,
+		"Definitions": s.Definitions,
+		"Keys":        defs,
+	}))
+
+	formatted, err := format.Source(source.Bytes())
+	check(err)
+
+	check(os.WriteFile(*output, formatted, 0644))
+}


### PR DESCRIPTION
To keep the enums in the advisory loader in sync with the json schema files.
generate the respective Go types with `go generate` directly from the schemata.